### PR TITLE
Update JMeter to 2.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "gruntplugin"
   ],
   "bin": {
-    "jmeter-manager": "bin/jmeter-manager",
-    "jmeter": "bin/jmeter"
+    "jmeter-manager": "bin/jmeter-manager"
   },
   "files": [
     "bin",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "gruntplugin"
   ],
   "bin": {
-    "jmeter-manager": "bin/jmeter-manager",
-    "jmeter": "bin/jmeter"
+    "jmeter-manager": "bin/jmeter-manager"
   },
   "files": [
     "bin",
@@ -45,6 +44,6 @@
     "LICENSE"
   ],
   "jmeterVersions": {
-    "jmeter": "2.11"
+    "jmeter": "2.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-jmeter",
   "description": "Run jmeter tests with grunt.",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "homepage": "https://github.com/pcw216/grunt-jmeter",
   "author": {
     "name": "Patrick Winters",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "LICENSE"
   ],
   "jmeterVersions": {
-    "jmeter": "2.11"
+    "jmeter": "2.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "gruntplugin"
   ],
   "bin": {
-    "jmeter-manager": "bin/jmeter-manager"
+    "jmeter-manager": "bin/jmeter-manager",
+    "jmeter": "bin/jmeter"
   },
   "files": [
     "bin",
@@ -44,6 +45,6 @@
     "LICENSE"
   ],
   "jmeterVersions": {
-    "jmeter": "2.12"
+    "jmeter": "2.11"
   }
 }


### PR DESCRIPTION
Apache has pulled the 2.11 hosted archive. I've updated the version to 2.12. Also, I removed the reference to `bin/jmeter` in the package because that file doesn't exist and throws an ENOENT error during install.
